### PR TITLE
Move contact abbreviated names retrieval to Product trait

### DIFF
--- a/src/Traits/Contact.php
+++ b/src/Traits/Contact.php
@@ -209,27 +209,4 @@ trait Contact
         return $this->execute();
     }
 
-    /**
-     * Retrieves all abbreviated names of contacts for a specified API version.
-     *
-     * This method sends a GET request to the 'contacts/abbreviatedNames' endpoint to fetch a list of all abbreviated names.
-     * It initializes the request, sets the API version, and executes the request.
-     *
-     * @param  string  $version  (Optional) The version of the API to target. Defaults to 'v1'.
-     * @return mixed The response from the API, typically an object or array containing the list of abbreviated names.
-     *
-     * @throws \Exception If an error occurs during the request execution.
-     */
-    public function getAllAbbreviatedNames(string $version = 'v1'): mixed
-    {
-        $this->init();
-        $this->setVersion($version);
-        $this->setData([
-            'query' => http_build_query([]),
-        ]);
-        $this->setEndpoint('contacts/abbreviatedNames');
-        $this->setRequestType('GET');
-
-        return $this->execute();
-    }
 }

--- a/src/Traits/Contact.php
+++ b/src/Traits/Contact.php
@@ -208,5 +208,4 @@ trait Contact
 
         return $this->execute();
     }
-
 }

--- a/src/Traits/Product.php
+++ b/src/Traits/Product.php
@@ -145,4 +145,28 @@ trait Product
 
         return $this->execute();
     }
+
+    /**
+     * Retrieves all abbreviated names of contacts for a specified API version.
+     *
+     * This method sends a GET request to the 'contact-product/abbreviatedNames' endpoint to fetch a list of all abbreviated names.
+     * It initializes the request, sets the API version, and executes the request.
+     *
+     * @param  string  $version  (Optional) The version of the API to target. Defaults to 'v1'.
+     * @return mixed The response from the API, typically an object or array containing the list of abbreviated names.
+     *
+     * @throws \Exception If an error occurs during the request execution.
+     */
+    public function getAllAbbreviatedNames(string $version = 'v1'): mixed
+    {
+        $this->init();
+        $this->setVersion($version);
+        $this->setData([
+            'query' => http_build_query([]),
+        ]);
+        $this->setEndpoint('contact-product/abbreviatedNames');
+        $this->setRequestType('GET');
+
+        return $this->execute();
+    }
 }


### PR DESCRIPTION
Relocates the `getAllAbbreviatedNames` method from the `Contact` trait to the `Product` trait. This change updates the API endpoint from `contacts/abbreviatedNames` to `contact-product/abbreviatedNames`, aligning the method with the `contact-product` API resource.
