### PR TITLE
Fix bulkUpdateContact to perform true bulk operations

### DIFF
--- a/src/Traits/Contact.php
+++ b/src/Traits/Contact.php
@@ -99,14 +99,13 @@ trait Contact
     }
 
     /**
-     * Bulk updates specific contact by ID with provided data for a specified API version.
+     * Bulk updates with provided data for a specified API version.
      *
      * This method prepares the request to bulk update contacts identified by the given ID with the provided data array.
      * It sets the API version, configures the data payload as form parameters, sets the endpoint to target the specific
      * contact by appending the ID to the 'contacts/' endpoint, and specifies the request type as 'PUT'.
      * Finally, it executes the request and returns the response.
      *
-     * @param  string  $id  The unique identifier of the contact to update.
      * @param  array  $data  (Optional) An associative array of data to update the contact with. The array keys and values
      *                       depend on the contact model's attributes and the API's update capabilities.
      * @param  string  $version  (Optional) The version of the API to target. Defaults to 'v1'.
@@ -115,14 +114,14 @@ trait Contact
      *
      * @throws \Exception
      */
-    public function bulkUpdateContact(string $id, array $data = [], string $version = 'v1'): mixed
+    public function bulkUpdateContact(array $data = [], string $version = 'v1'): mixed
     {
         $this->init();
         $this->setVersion($version);
         $this->setData([
             'json' => $data,
         ]);
-        $this->setEndpoint('contacts/bulkUpdate/'.$id);
+        $this->setEndpoint('contacts/bulkUpdate');
         $this->setRequestType('PUT');
 
         return $this->execute();

--- a/tests/Traits/ContactTest.php
+++ b/tests/Traits/ContactTest.php
@@ -101,7 +101,7 @@ test('bulkUpdateContact calls expected methods and returns result', function () 
     $expectedResult = 'update-contact-result';
     $mock->expects($this->once())->method('execute')->willReturn($expectedResult);
 
-    $result = $mock->bulkUpdateContact($id, $data, $version);
+    $result = $mock->bulkUpdateContact($data, $version);
     expect($result)->toBe($expectedResult);
 });
 

--- a/tests/Traits/ContactTest.php
+++ b/tests/Traits/ContactTest.php
@@ -95,7 +95,7 @@ test('bulkUpdateContact calls expected methods and returns result', function () 
     $mock->expects($this->once())->method('init')->willReturnSelf();
     $mock->expects($this->once())->method('setVersion')->with($version)->willReturnSelf();
     $mock->expects($this->once())->method('setData')->with(['json' => $data])->willReturnSelf();
-    $mock->expects($this->once())->method('setEndpoint')->with('contacts/bulkUpdate/'.$id)->willReturnSelf();
+    $mock->expects($this->once())->method('setEndpoint')->with('contacts/bulkUpdate')->willReturnSelf();
     $mock->expects($this->once())->method('setRequestType')->with('PUT')->willReturnSelf();
 
     $expectedResult = 'update-contact-result';


### PR DESCRIPTION
The method no longer takes a single ID in the URL to update a specific contact. Instead, it now uses a dedicated bulk endpoint, expecting the target entities for the bulk update to be defined within the data payload.
