### PR TITLE
Requires contact ID for bank accounts retrieval

### DIFF
--- a/src/Traits/BankAccount.php
+++ b/src/Traits/BankAccount.php
@@ -12,7 +12,7 @@ trait BankAccount
      * the API version, and initiates a GET request to the 'contacts' endpoint. The response from the execution of this
      * request is returned, which may include a list of contacts along with any specified related resources.
      *
-     * @param string $id The unique identifier of the contact who's bank accounts to retrieve.
+     * @param  string  $id  The unique identifier of the contact who's bank accounts to retrieve.
      * @param  array  $filters  (Optional) An associative array of filters to apply to the contact retrieval. The array keys
      *                          and values depend on the contact model's attributes and the API's filtering capabilities.
      * @param  array  $includes  (Optional) An array of related resources to include in the response for each contact.

--- a/src/Traits/BankAccount.php
+++ b/src/Traits/BankAccount.php
@@ -12,6 +12,7 @@ trait BankAccount
      * the API version, and initiates a GET request to the 'contacts' endpoint. The response from the execution of this
      * request is returned, which may include a list of contacts along with any specified related resources.
      *
+     * @param string $id The unique identifier of the contact who's bank accounts to retrieve.
      * @param  array  $filters  (Optional) An associative array of filters to apply to the contact retrieval. The array keys
      *                          and values depend on the contact model's attributes and the API's filtering capabilities.
      * @param  array  $includes  (Optional) An array of related resources to include in the response for each contact.
@@ -25,14 +26,14 @@ trait BankAccount
      *
      * @throws \Exception
      */
-    public function contactBankAccounts(array $filters = [], array $includes = [], array $sort = [], string $version = 'v1', int $per_page = 15, ?int $page = null): mixed
+    public function contactBankAccounts(string $contactNumber, array $filters = [], array $includes = [], array $sort = [], string $version = 'v1', int $per_page = 15, ?int $page = null): mixed
     {
         $this->init();
         $this->setVersion($version);
         $this->setData([
             'query' => http_build_query(['filter' => $filters, 'include' => $includes, 'sort' => $sort, 'per-page' => $per_page, 'page' => $page ?? 1]),
         ]);
-        $this->setEndpoint('contact-bank-account');
+        $this->setEndpoint('contact-bank-account/'.$contactNumber);
         $this->setRequestType('GET');
 
         return $this->execute();

--- a/tests/Traits/BankAccountTest.php
+++ b/tests/Traits/BankAccountTest.php
@@ -8,6 +8,7 @@ test('contactBankAccounts calls expected methods and returns result', function (
         ->getMock();
 
     $filters = ['active' => true];
+    $contactNumber = 'contact-123';
     $includes = ['contact'];
     $sort = ['created_at'];
     $version = 'v1.1';
@@ -26,13 +27,13 @@ test('contactBankAccounts calls expected methods and returns result', function (
             && $queryArray['per-page'] == $per_page
             && $queryArray['page'] == $page;
     }))->willReturnSelf();
-    $mock->expects($this->once())->method('setEndpoint')->with('contact-bank-account')->willReturnSelf();
+    $mock->expects($this->once())->method('setEndpoint')->with('contact-bank-account/'.$contactNumber)->willReturnSelf();
     $mock->expects($this->once())->method('setRequestType')->with('GET')->willReturnSelf();
 
     $expectedResult = 'bank-accounts-result';
     $mock->expects($this->once())->method('execute')->willReturn($expectedResult);
 
-    $result = $mock->contactBankAccounts($filters, $includes, $sort, $version, $per_page, $page);
+    $result = $mock->contactBankAccounts($contactNumber, $filters, $includes, $sort, $version, $per_page, $page);
     expect($result)->toBe($expectedResult);
 });
 


### PR DESCRIPTION
Updates the `contactBankAccounts` method to explicitly require a `contact ID` parameter. This ID is now used to construct a contact-specific API endpoint, ensuring that bank account retrieval targets the correct contact's resources. Related tests are updated to reflect this change.